### PR TITLE
docs: fix typo #61197

### DIFF
--- a/src/doc/rustdoc/src/the-doc-attribute.md
+++ b/src/doc/rustdoc/src/the-doc-attribute.md
@@ -202,7 +202,7 @@ mod bar {
 Now we'll have a `Re-exports` line, and `Bar` will not link to anywhere.
 
 One special case: In Rust 2018 and later, if you `pub use` one of your dependencies, `rustdoc` will
-not eagerly inline it as a module unless you add `#[doc(inline)}`.
+not eagerly inline it as a module unless you add `#[doc(inline)]`.
 
 ## `#[doc(hidden)]`
 


### PR DESCRIPTION
Fixes #61197

Change `#[doc(inline)}` to `#[doc(inline)]` in the [#[doc]](https://doc.rust-lang.org/rustdoc/the-doc-attribute.html) documentation.